### PR TITLE
fix: escape file paths with special characters in ]f/[f keymaps

### DIFF
--- a/lua/unimpaired/functions.lua
+++ b/lua/unimpaired/functions.lua
@@ -170,7 +170,7 @@ M.previous_file = function()
     else
         local file = file_by_offset(-vim.v.count1)
         if file then
-            vim.cmd('edit ' .. file)
+            vim.cmd('edit ' .. vim.fn.fnameescape(file))
         end
     end
 end
@@ -186,7 +186,7 @@ M.next_file = function()
     else
         local file = file_by_offset(vim.v.count1)
         if file then
-            vim.cmd('edit ' .. file)
+            vim.cmd('edit ' .. vim.fn.fnameescape(file))
         end
     end
 end


### PR DESCRIPTION
## Summary

- Wrap file paths with `vim.fn.fnameescape()` in `previous_file` and `next_file` functions
- Fixes `E500` errors when navigating to files containing special characters (e.g., `#`) in their names

## Problem

Filenames containing special characters like `#` (e.g., [YADM](https://yadm.io/) alternative files with `##class.Personal` suffix) cause `E500: Evaluates to an empty string` errors when passed unescaped to `vim.cmd('edit ...')`.

## Solution

Use `vim.fn.fnameescape()` to properly escape file paths before passing them to the `:edit` command, consistent with how Vim/Neovim expects special characters to be handled in command-line arguments.